### PR TITLE
Add  crypto_sign functions

### DIFF
--- a/csodium/__init__.py
+++ b/csodium/__init__.py
@@ -434,6 +434,40 @@ def crypto_sign_open(signed_msg, pk):
 
     return binary_type(msg)
 
+
+def crypto_sign_detached(msg, sk):
+    _assert_len('sk', sk, crypto_sign_SECRETKEYBYTES)
+
+    sig = bytearray(crypto_sign_BYTES)
+    _raise_on_error(
+        lib.crypto_sign_detached(
+            ffi.cast("unsigned char *", ffi.from_buffer(sig)),
+            ffi.NULL,
+            msg,
+            len(msg),
+            sk,
+        ),
+    )
+
+    return binary_type(sig)
+
+
+def crypto_sign_verify_detached(msg, sig, pk):
+    _assert_len('sig', sig, crypto_sign_BYTES)
+    _assert_len('pk', pk, crypto_sign_PUBLICKEYBYTES)
+
+    _raise_on_error(
+        lib.crypto_sign_verify_detached(
+            sig,
+            msg,
+            len(msg),
+            pk,
+        ),
+    )
+
+    return True
+
+
 # ed25519 sign specific functions
 crypto_sign_ed25519_SEEDBYTES = lib.crypto_sign_ed25519_seedbytes()
 crypto_sign_ed25519_PUBLICKEYBYTES = lib.crypto_sign_ed25519_publickeybytes()

--- a/csodium/__init__.py
+++ b/csodium/__init__.py
@@ -36,7 +36,7 @@ def _assert_len(name, buf, size, max_size=None):
 # random family.
 def randombytes(size):
     buf = bytearray(size)
-    lib.randombytes(ffi.from_buffer(buf), size)
+    lib.randombytes(ffi.cast("unsigned char *", ffi.from_buffer(buf)), size)
     return binary_type(buf)
 
 
@@ -55,8 +55,8 @@ def crypto_box_keypair():
     sk = bytearray(crypto_box_SECRETKEYBYTES)
     _raise_on_error(
         lib.crypto_box_keypair(
-            ffi.from_buffer(pk),
-            ffi.from_buffer(sk),
+            ffi.cast("unsigned char *", ffi.from_buffer(pk)),
+            ffi.cast("unsigned char *", ffi.from_buffer(sk)),
         ),
     )
 
@@ -70,8 +70,8 @@ def crypto_box_seed_keypair(seed):
     sk = bytearray(crypto_box_SECRETKEYBYTES)
     _raise_on_error(
         lib.crypto_box_seed_keypair(
-            ffi.from_buffer(pk),
-            ffi.from_buffer(sk),
+            ffi.cast("unsigned char *", ffi.from_buffer(pk)),
+            ffi.cast("unsigned char *", ffi.from_buffer(sk)),
             seed,
         ),
     )
@@ -86,7 +86,7 @@ def crypto_box_beforenm(pk, sk):
     k = bytearray(crypto_box_BEFORENMBYTES)
     _raise_on_error(
         lib.crypto_box_beforenm(
-            ffi.from_buffer(k),
+            ffi.cast("unsigned char *", ffi.from_buffer(k)),
             pk,
             sk,
         ),
@@ -103,7 +103,7 @@ def crypto_box(msg, nonce, pk, sk):
     c = bytearray(crypto_box_MACBYTES + len(msg))
     _raise_on_error(
         lib.crypto_box_easy(
-            ffi.from_buffer(c),
+            ffi.cast("unsigned char *", ffi.from_buffer(c)),
             msg,
             len(msg),
             nonce,
@@ -122,7 +122,7 @@ def crypto_box_afternm(msg, nonce, k):
     c = bytearray(crypto_box_MACBYTES + len(msg))
     _raise_on_error(
         lib.crypto_box_easy_afternm(
-            ffi.from_buffer(c),
+            ffi.cast("unsigned char *", ffi.from_buffer(c)),
             msg,
             len(msg),
             nonce,
@@ -141,7 +141,7 @@ def crypto_box_open(c, nonce, pk, sk):
     msg = bytearray(len(c) - crypto_box_MACBYTES)
     _raise_on_error(
         lib.crypto_box_open_easy(
-            ffi.from_buffer(msg),
+            ffi.cast("unsigned char *", ffi.from_buffer(msg)),
             c,
             len(c),
             nonce,
@@ -160,7 +160,7 @@ def crypto_box_open_afternm(c, nonce, k):
     msg = bytearray(len(c) - crypto_box_MACBYTES)
     _raise_on_error(
         lib.crypto_box_open_easy_afternm(
-            ffi.from_buffer(msg),
+            ffi.cast("unsigned char *", ffi.from_buffer(msg)),
             c,
             len(c),
             nonce,
@@ -177,7 +177,7 @@ def crypto_box_seal(msg, pk):
     c = bytearray(len(msg) + crypto_box_SEALBYTES)
     _raise_on_error(
         lib.crypto_box_seal(
-            ffi.from_buffer(c),
+            ffi.cast("unsigned char *", ffi.from_buffer(c)),
             msg,
             len(msg),
             pk,
@@ -194,7 +194,7 @@ def crypto_box_seal_open(c, pk, sk):
     msg = bytearray(len(c) - crypto_box_SEALBYTES)
     _raise_on_error(
         lib.crypto_box_seal_open(
-            ffi.from_buffer(msg),
+            ffi.cast("unsigned char *", ffi.from_buffer(msg)),
             c,
             len(c),
             pk,
@@ -214,8 +214,8 @@ def crypto_box_detached(msg, nonce, pk, sk):
     mac = bytearray(crypto_box_MACBYTES)
     _raise_on_error(
         lib.crypto_box_detached(
-            ffi.from_buffer(c),
-            ffi.from_buffer(mac),
+            ffi.cast("unsigned char *", ffi.from_buffer(c)),
+            ffi.cast("unsigned char *", ffi.from_buffer(mac)),
             msg,
             len(msg),
             nonce,
@@ -236,7 +236,7 @@ def crypto_box_open_detached(c, mac, nonce, pk, sk):
     msg = bytearray(len(c))
     _raise_on_error(
         lib.crypto_box_open_detached(
-            ffi.from_buffer(msg),
+            ffi.cast("unsigned char *", ffi.from_buffer(msg)),
             c,
             mac,
             len(c),
@@ -262,7 +262,7 @@ def crypto_secretbox(msg, nonce, k):
     c = bytearray(crypto_secretbox_MACBYTES + len(msg))
     _raise_on_error(
         lib.crypto_secretbox_easy(
-            ffi.from_buffer(c),
+            ffi.cast("unsigned char *", ffi.from_buffer(c)),
             msg,
             len(msg),
             nonce,
@@ -280,7 +280,7 @@ def crypto_secretbox_open(c, nonce, k):
     msg = bytearray(len(c) - crypto_secretbox_MACBYTES)
     _raise_on_error(
         lib.crypto_secretbox_open_easy(
-            ffi.from_buffer(msg),
+            ffi.cast("unsigned char *", ffi.from_buffer(msg)),
             c,
             len(c),
             nonce,

--- a/csodium/__init__.py
+++ b/csodium/__init__.py
@@ -33,6 +33,14 @@ def _assert_len(name, buf, size, max_size=None):
         assert len(buf) == size, "%s must be %d byte(s) long" % (name, size)
 
 
+def _assert_min_len(name, buf, min_size):
+    assert buf, "%s cannot be NULL" % name
+
+    assert min_size <= len(buf), (
+            "%s must be at least %d bytes long" % (name, min_size)
+        )
+
+
 # random family.
 def randombytes(size):
     buf = bytearray(size)
@@ -134,6 +142,7 @@ def crypto_box_afternm(msg, nonce, k):
 
 
 def crypto_box_open(c, nonce, pk, sk):
+    _assert_min_len('c', c, crypto_box_MACBYTES)
     _assert_len('nonce', nonce, crypto_box_NONCEBYTES)
     _assert_len('pk', pk, crypto_box_PUBLICKEYBYTES)
     _assert_len('sk', sk, crypto_box_SECRETKEYBYTES)
@@ -154,6 +163,7 @@ def crypto_box_open(c, nonce, pk, sk):
 
 
 def crypto_box_open_afternm(c, nonce, k):
+    _assert_min_len('c', c, crypto_box_MACBYTES)
     _assert_len('nonce', nonce, crypto_box_NONCEBYTES)
     _assert_len('k', k, crypto_box_BEFORENMBYTES)
 
@@ -188,6 +198,7 @@ def crypto_box_seal(msg, pk):
 
 
 def crypto_box_seal_open(c, pk, sk):
+    _assert_min_len('c', c, crypto_box_SEALBYTES)
     _assert_len('pk', pk, crypto_box_PUBLICKEYBYTES)
     _assert_len('sk', sk, crypto_box_SECRETKEYBYTES)
 
@@ -274,6 +285,7 @@ def crypto_secretbox(msg, nonce, k):
 
 
 def crypto_secretbox_open(c, nonce, k):
+    _assert_min_len('c', c, crypto_secretbox_MACBYTES)
     _assert_len('nonce', nonce, crypto_secretbox_NONCEBYTES)
     _assert_len('k', k, crypto_secretbox_KEYBYTES)
 

--- a/csodium/__init__.py
+++ b/csodium/__init__.py
@@ -370,6 +370,7 @@ crypto_sign_SEEDBYTES = lib.crypto_sign_seedbytes()
 crypto_sign_PUBLICKEYBYTES = lib.crypto_sign_publickeybytes()
 crypto_sign_SECRETKEYBYTES = lib.crypto_sign_secretkeybytes()
 
+
 def crypto_sign_keypair():
     pk = bytearray(crypto_sign_PUBLICKEYBYTES)
     sk = bytearray(crypto_sign_SECRETKEYBYTES)
@@ -381,6 +382,7 @@ def crypto_sign_keypair():
     )
 
     return binary_type(pk), binary_type(sk)
+
 
 def crypto_sign_seed_keypair(seed):
     _assert_len('seed', seed, crypto_sign_SEEDBYTES)
@@ -397,6 +399,7 @@ def crypto_sign_seed_keypair(seed):
 
     return binary_type(pk), binary_type(sk)
 
+
 def crypto_sign(msg, sk):
     _assert_len('sk', sk, crypto_sign_SECRETKEYBYTES)
 
@@ -412,6 +415,7 @@ def crypto_sign(msg, sk):
     )
 
     return binary_type(signed_msg)
+
 
 def crypto_sign_open(signed_msg, pk):
     _assert_min_len('signed_msg', signed_msg, crypto_sign_BYTES)
@@ -431,10 +435,11 @@ def crypto_sign_open(signed_msg, pk):
     return binary_type(msg)
 
 # ed25519 sign specific functions
-crypto_sign_ed25519_SEEDBYTES =  lib.crypto_sign_ed25519_seedbytes()
+crypto_sign_ed25519_SEEDBYTES = lib.crypto_sign_ed25519_seedbytes()
 crypto_sign_ed25519_PUBLICKEYBYTES = lib.crypto_sign_ed25519_publickeybytes()
 crypto_sign_ed25519_SECRETKEYBYTES = lib.crypto_sign_ed25519_secretkeybytes()
-crypto_scalarmult_curve25519_BYTES =  lib.crypto_scalarmult_curve25519_bytes()
+crypto_scalarmult_curve25519_BYTES = lib.crypto_scalarmult_curve25519_bytes()
+
 
 def crypto_sign_ed25519_pk_to_curve25519(ed25519_pk):
     _assert_len("ed25519_pk", ed25519_pk, crypto_sign_ed25519_PUBLICKEYBYTES)
@@ -448,6 +453,7 @@ def crypto_sign_ed25519_pk_to_curve25519(ed25519_pk):
 
     return binary_type(curve25519_pk)
 
+
 def crypto_sign_ed25519_sk_to_curve25519(ed25519_sk):
     _assert_len("ed25519_sk", ed25519_sk, crypto_sign_ed25519_SECRETKEYBYTES)
     curve25519_sk = bytearray(crypto_scalarmult_curve25519_BYTES)
@@ -460,6 +466,7 @@ def crypto_sign_ed25519_sk_to_curve25519(ed25519_sk):
 
     return binary_type(curve25519_sk)
 
+
 def crypto_sign_ed25519_sk_to_seed(sk):
     _assert_len("sk", sk, crypto_sign_ed25519_SECRETKEYBYTES)
     seed = bytearray(crypto_sign_ed25519_SEEDBYTES)
@@ -471,6 +478,7 @@ def crypto_sign_ed25519_sk_to_seed(sk):
     )
 
     return binary_type(seed)
+
 
 def crypto_sign_ed25519_sk_to_pk(sk):
     _assert_len("sk", sk, crypto_sign_ed25519_SECRETKEYBYTES)

--- a/csodium/__init__.py
+++ b/csodium/__init__.py
@@ -47,7 +47,6 @@ def randombytes(size):
     lib.randombytes(ffi.cast("unsigned char *", ffi.from_buffer(buf)), size)
     return binary_type(buf)
 
-
 # crypto_box family.
 crypto_box_BEFORENMBYTES = lib.crypto_box_beforenmbytes()
 crypto_box_MACBYTES = lib.crypto_box_macbytes()
@@ -364,3 +363,123 @@ def crypto_generichash_blake2b_salt_personal(
         ),
     )
     return binary_type(buf)
+
+# crypto_sign family
+crypto_sign_BYTES = lib.crypto_sign_bytes()
+crypto_sign_SEEDBYTES = lib.crypto_sign_seedbytes()
+crypto_sign_PUBLICKEYBYTES = lib.crypto_sign_publickeybytes()
+crypto_sign_SECRETKEYBYTES = lib.crypto_sign_secretkeybytes()
+
+def crypto_sign_keypair():
+    pk = bytearray(crypto_sign_PUBLICKEYBYTES)
+    sk = bytearray(crypto_sign_SECRETKEYBYTES)
+    _raise_on_error(
+        lib.crypto_sign_keypair(
+            ffi.cast("unsigned char *", ffi.from_buffer(pk)),
+            ffi.cast("unsigned char *", ffi.from_buffer(sk)),
+        ),
+    )
+
+    return binary_type(pk), binary_type(sk)
+
+def crypto_sign_seed_keypair(seed):
+    _assert_len('seed', seed, crypto_sign_SEEDBYTES)
+
+    pk = bytearray(crypto_sign_PUBLICKEYBYTES)
+    sk = bytearray(crypto_sign_SECRETKEYBYTES)
+    _raise_on_error(
+        lib.crypto_sign_seed_keypair(
+            ffi.cast("unsigned char *", ffi.from_buffer(pk)),
+            ffi.cast("unsigned char *", ffi.from_buffer(sk)),
+            seed,
+        ),
+    )
+
+    return binary_type(pk), binary_type(sk)
+
+def crypto_sign(msg, sk):
+    _assert_len('sk', sk, crypto_sign_SECRETKEYBYTES)
+
+    signed_msg = bytearray(crypto_sign_BYTES + len(msg))
+    _raise_on_error(
+        lib.crypto_sign(
+            ffi.cast("unsigned char *", ffi.from_buffer(signed_msg)),
+            ffi.NULL,
+            msg,
+            len(msg),
+            sk,
+        ),
+    )
+
+    return binary_type(signed_msg)
+
+def crypto_sign_open(signed_msg, pk):
+    _assert_min_len('signed_msg', signed_msg, crypto_sign_BYTES)
+    _assert_len('pk', pk, crypto_sign_PUBLICKEYBYTES)
+
+    msg = bytearray(len(signed_msg) - crypto_sign_BYTES)
+    _raise_on_error(
+        lib.crypto_sign_open(
+            ffi.cast("unsigned char *", ffi.from_buffer(msg)),
+            ffi.NULL,
+            signed_msg,
+            len(signed_msg),
+            pk,
+        ),
+    )
+
+    return binary_type(msg)
+
+# ed25519 sign specific functions
+crypto_sign_ed25519_SEEDBYTES =  lib.crypto_sign_ed25519_seedbytes()
+crypto_sign_ed25519_PUBLICKEYBYTES = lib.crypto_sign_ed25519_publickeybytes()
+crypto_sign_ed25519_SECRETKEYBYTES = lib.crypto_sign_ed25519_secretkeybytes()
+crypto_scalarmult_curve25519_BYTES =  lib.crypto_scalarmult_curve25519_bytes()
+
+def crypto_sign_ed25519_pk_to_curve25519(ed25519_pk):
+    _assert_len("ed25519_pk", ed25519_pk, crypto_sign_ed25519_PUBLICKEYBYTES)
+    curve25519_pk = bytearray(crypto_scalarmult_curve25519_BYTES)
+    _raise_on_error(
+        lib.crypto_sign_ed25519_pk_to_curve25519(
+            ffi.cast("unsigned char *", ffi.from_buffer(curve25519_pk)),
+            ffi.cast("unsigned char *", ffi.from_buffer(ed25519_pk)),
+        ),
+    )
+
+    return binary_type(curve25519_pk)
+
+def crypto_sign_ed25519_sk_to_curve25519(ed25519_sk):
+    _assert_len("ed25519_sk", ed25519_sk, crypto_sign_ed25519_SECRETKEYBYTES)
+    curve25519_sk = bytearray(crypto_scalarmult_curve25519_BYTES)
+    _raise_on_error(
+        lib.crypto_sign_ed25519_sk_to_curve25519(
+            ffi.cast("unsigned char *", ffi.from_buffer(curve25519_sk)),
+            ffi.cast("unsigned char *", ffi.from_buffer(ed25519_sk)),
+        ),
+    )
+
+    return binary_type(curve25519_sk)
+
+def crypto_sign_ed25519_sk_to_seed(sk):
+    _assert_len("sk", sk, crypto_sign_ed25519_SECRETKEYBYTES)
+    seed = bytearray(crypto_sign_ed25519_SEEDBYTES)
+    _raise_on_error(
+        lib.crypto_sign_ed25519_sk_to_seed(
+            ffi.cast("unsigned char *", ffi.from_buffer(seed)),
+            sk,
+        ),
+    )
+
+    return binary_type(seed)
+
+def crypto_sign_ed25519_sk_to_pk(sk):
+    _assert_len("sk", sk, crypto_sign_ed25519_SECRETKEYBYTES)
+    pk = bytearray(crypto_sign_ed25519_PUBLICKEYBYTES)
+    _raise_on_error(
+        lib.crypto_sign_ed25519_sk_to_pk(
+            ffi.cast("unsigned char *", ffi.from_buffer(pk)),
+            sk,
+        ),
+    )
+
+    return binary_type(pk)

--- a/csodium/_build.py
+++ b/csodium/_build.py
@@ -133,6 +133,35 @@ int crypto_generichash_blake2b_salt_personal(
     const void* salt,
     const void* personal
 );
+
+size_t  crypto_sign_bytes(void);
+size_t  crypto_sign_seedbytes(void);
+size_t  crypto_sign_publickeybytes(void);
+size_t  crypto_sign_secretkeybytes(void);
+
+int crypto_sign_seed_keypair(unsigned char *pk, unsigned char *sk,
+                             const unsigned char *seed);
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+int crypto_sign(unsigned char *sm, unsigned long long *smlen_p,
+                const unsigned char *m, unsigned long long mlen,
+                const unsigned char *sk);
+int crypto_sign_open(unsigned char *m, unsigned long long *mlen_p,
+                     const unsigned char *sm, unsigned long long smlen,
+                     const unsigned char *pk);
+
+size_t crypto_sign_ed25519_seedbytes(void);
+size_t crypto_sign_ed25519_publickeybytes(void);
+size_t crypto_sign_ed25519_secretkeybytes(void);
+size_t crypto_scalarmult_curve25519_bytes(void);
+
+int crypto_sign_ed25519_pk_to_curve25519(unsigned char *curve25519_pk,
+                                         const unsigned char *ed25519_pk);
+int crypto_sign_ed25519_sk_to_curve25519(unsigned char *curve25519_sk,
+                                         const unsigned char *ed25519_sk);
+int crypto_sign_ed25519_sk_to_seed(unsigned char *seed,
+                                   const unsigned char *sk);
+int crypto_sign_ed25519_sk_to_pk(unsigned char *pk, const unsigned char *sk);
+
 ''')
 
 # On Windows, we compile with libsodium statically, so that users of the wheel

--- a/csodium/_build.py
+++ b/csodium/_build.py
@@ -148,6 +148,15 @@ int crypto_sign(unsigned char *sm, unsigned long long *smlen_p,
 int crypto_sign_open(unsigned char *m, unsigned long long *mlen_p,
                      const unsigned char *sm, unsigned long long smlen,
                      const unsigned char *pk);
+int crypto_sign_detached(unsigned char *sig, unsigned long long *siglen_p,
+                         const unsigned char *m, unsigned long long mlen,
+                         const unsigned char *sk);
+int crypto_sign_verify_detached(const unsigned char *sig,
+                                const unsigned char *m,
+                                unsigned long long mlen,
+                                const unsigned char *pk);
+
+
 
 size_t crypto_sign_ed25519_seedbytes(void);
 size_t crypto_sign_ed25519_publickeybytes(void);
@@ -161,6 +170,7 @@ int crypto_sign_ed25519_sk_to_curve25519(unsigned char *curve25519_sk,
 int crypto_sign_ed25519_sk_to_seed(unsigned char *seed,
                                    const unsigned char *sk);
 int crypto_sign_ed25519_sk_to_pk(unsigned char *pk, const unsigned char *sk);
+
 
 ''')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,7 +93,6 @@ def personal():
     return b'x' * crypto_generichash_blake2b_PERSONALBYTES
 
 
-
 @pytest.fixture
 def sign_pk():
     pk, _ = crypto_sign_seed_keypair(b'x' * crypto_sign_SEEDBYTES)
@@ -591,9 +590,11 @@ def test_crypto_sign_keypair():
     assert len(pk) == crypto_sign_PUBLICKEYBYTES
     assert len(sk) == crypto_sign_SECRETKEYBYTES
 
+
 def test_crypto_sign_seed_keypair_invalid_seed():
     with pytest.raises(AssertionError):
         crypto_sign_seed_keypair(b'invalid')
+
 
 def test_crypto_sign_seed_keypair():
     pk, sk = crypto_sign_seed_keypair(b'x' * crypto_sign_SEEDBYTES)
@@ -608,8 +609,9 @@ def test_crypto_sign_invalid_pk():
             sk=b'',
         )
 
+
 def test_crypto_sign(sign_sk):
-    msg=b'foo'
+    msg = b'foo'
     signed_msg = crypto_sign(
         msg=msg,
         sk=sign_sk,
@@ -625,12 +627,14 @@ def test_crypto_sign_open_invalid_pk():
             pk=b'',
         )
 
+
 def test_crypto_sign_open_failure(sign_pk):
     with pytest.raises(ValueError):
         crypto_sign_open(
             signed_msg=b'x' * 100,
             pk=sign_pk,
         )
+
 
 def test_crypto_sign_open(sign_pk, sign_sk):
     signed_msg = crypto_sign(
@@ -648,30 +652,45 @@ def test_crypto_sign_ed25519_pk_to_curve25519_invalid_pk():
     with pytest.raises(AssertionError):
         crypto_sign_ed25519_pk_to_curve25519(b'invalid')
 
+
 def test_crypto_sign_ed25519_pk_to_curve25519():
-    curve_pk = crypto_sign_ed25519_pk_to_curve25519(b'x' * crypto_sign_ed25519_PUBLICKEYBYTES)
+    curve_pk = crypto_sign_ed25519_pk_to_curve25519(
+        b'x' * crypto_sign_ed25519_PUBLICKEYBYTES
+    )
     assert len(curve_pk) == crypto_scalarmult_curve25519_BYTES
+
 
 def test_crypto_sign_ed25519_sk_to_curve25519_invalid_sk():
     with pytest.raises(AssertionError):
         crypto_sign_ed25519_sk_to_curve25519(b'invalid')
 
+
 def test_crypto_sign_ed25519_sk_to_curve25519():
-    curve_sk = crypto_sign_ed25519_sk_to_curve25519(b'x' * crypto_sign_ed25519_SECRETKEYBYTES)
+    curve_sk = crypto_sign_ed25519_sk_to_curve25519(
+        b'x' * crypto_sign_ed25519_SECRETKEYBYTES
+    )
     assert len(curve_sk) == crypto_scalarmult_curve25519_BYTES
+
 
 def test_crypto_sign_ed25519_sk_to_seed_invalid_sk():
     with pytest.raises(AssertionError):
         crypto_sign_ed25519_sk_to_seed(b'invalid')
 
+
 def test_crypto_sign_ed25519_sk_to_seed():
-    seed = crypto_sign_ed25519_sk_to_seed(b'x' * crypto_sign_ed25519_SECRETKEYBYTES)
+    seed = crypto_sign_ed25519_sk_to_seed(
+        b'x' * crypto_sign_ed25519_SECRETKEYBYTES
+    )
     assert len(seed) == crypto_sign_ed25519_SEEDBYTES
+
 
 def test_crypto_sign_ed25519_sk_to_pk_invalid_sk():
     with pytest.raises(AssertionError):
         crypto_sign_ed25519_sk_to_pk(b'invalid')
 
+
 def test_crypto_sign_ed25519_sk_to_pk():
-    pk = crypto_sign_ed25519_sk_to_pk(b'x' * crypto_sign_ed25519_SECRETKEYBYTES)
+    pk = crypto_sign_ed25519_sk_to_pk(
+        b'x' * crypto_sign_ed25519_SECRETKEYBYTES
+    )
     assert len(pk) == crypto_sign_ed25519_PUBLICKEYBYTES


### PR DESCRIPTION
This handles more of the casts that are causing warnings in the newer version of cffi.